### PR TITLE
Fix for 

### DIFF
--- a/start.py
+++ b/start.py
@@ -167,7 +167,7 @@ BYTES_SEND = Counter()
 class Tools:
     IP = compile(r"(?:\d{1,3}\.){3}\d{1,3}")
     protocolRex = compile(r'"protocol":(\d+)')
-
+ 
     @staticmethod
     def humanbytes(i: int, binary: bool = False, precision: int = 2):
         MULTIPLES = [


### PR DESCRIPTION
The issue seems to be with the escape sequences in the regular expression. Here's how to manually address this:

Locate the problematic lines:

IP = compile("(?:\d{1,3}\.){3}\d{1,3}")
protocolRex = compile('"protocol":(\d+)')

Modify these lines to use raw strings (r"..."):

Replace:

IP = compile("(?:\d{1,3}\.){3}\d{1,3}")
protocolRex = compile('"protocol":(\d+)')

IP = compile(r"(?:\d{1,3}\.){3}\d{1,3}")
protocolRex = compile(r'"protocol":(\d+)')

Explanation:
Raw Strings (r"..."): Using raw strings in Python helps prevent issues with escape sequences. This is particularly useful in regular expressions where backslashes are common.

The lines should look exactly like this:

IP = compile(r"(?:\d{1,3}\.){3}\d{1,3}")
protocolRex = compile(r'"protocol":(\d+)')

MHDDoS/start.py:169: SyntaxWarning: invalid escape sequence '\d'
  protocolRex = compile('"protocol":(\d+)')

MHDDoS/start.py:168: SyntaxWarning: invalid escape sequence '\d'
  IP = compile("(?:\d{1,3}\.){3}\d{1,3}")