### PR TITLE
Fix "SyntaxWarning: invalid escape sequence" for regex compile function in Python 3.12

### DIFF
--- a/start.py
+++ b/start.py
@@ -165,8 +165,8 @@ BYTES_SEND = Counter()
 
 
 class Tools:
-    IP = compile("(?:\d{1,3}\.){3}\d{1,3}")
-    protocolRex = compile('"protocol":(\d+)')
+    IP = compile("(?:\\d{1,3}\\.){3}\\d{1,3}")
+    protocolRex = compile('"protocol":(\\d+)')
 
     @staticmethod
     def humanbytes(i: int, binary: bool = False, precision: int = 2):


### PR DESCRIPTION
There are language changes in Python 3.12 that prevents the regex pattern from retrieving IP addresses and protocol strings from proxy data. We should replace '\' with '\\'. This was tested with versions 3.10, 3.11, and 3.12.

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in https://github.com/python/cpython/issues/98401.)

Reference: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes
